### PR TITLE
fix a gosec warning 'G402: TLS MinVersion too low.'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,4 @@
 *.out
 
 # Dependency directories (remove the comment below to include it)
-# vendor/
-
-
+vendor/

--- a/eats/.golangci.yml
+++ b/eats/.golangci.yml
@@ -1,0 +1,49 @@
+run:
+  deadline: 3m
+  issues-exit-code: 1
+  tests: false
+
+output:
+  format: colored-line-number # colored-line-number|line-number|json|tab|checkstyle
+  print-issued-lines: true
+  print-linter-name: true
+
+linters:
+  disable-all: true
+  enable:
+    - govet
+    # - errcheck
+    - staticcheck
+    - unused
+    - gosimple
+    - structcheck
+    - varcheck
+    - ineffassign
+    - deadcode
+    - typecheck
+    # default disabled
+    - gosec
+    - unconvert
+    - goconst
+    - goimports
+    - megacheck
+    - misspell
+    - nakedret
+    - prealloc
+    - gocritic
+
+linters-settings:
+  govet:
+    check-shadowing: true
+  errcheck:
+    check-type-assertions: false
+    check-blank: false
+  unused:
+    check-exported: false
+  goconst:
+    min-len: 3
+    min-occurrences: 3
+  misspell:
+    locale: US
+  nakedret:
+    max-func-lines: 30

--- a/eats/Makefile
+++ b/eats/Makefile
@@ -1,0 +1,17 @@
+PWD := $(shell pwd)
+
+.PHONY: all deps test
+
+all: test
+
+deps:
+	@docker run --rm -t -v "$(PWD)":/app -w /app \
+			golang:1.16.5-alpine3.13 go mod vendor
+
+test:
+	@docker run --rm -t -v "$(PWD)":/app -w /app \
+			golangci/golangci-lint:v1.40.1-alpine \
+			golangci-lint run --config .golangci.yml
+	@docker run --rm -t -v "$(PWD)":/app -w /app \
+			--entrypoint go golang:1.16.5-alpine3.13 \
+			test -vet off $(go list ./...)

--- a/notification/.golangci.yml
+++ b/notification/.golangci.yml
@@ -1,0 +1,49 @@
+run:
+  deadline: 3m
+  issues-exit-code: 1
+  tests: false
+
+output:
+  format: colored-line-number # colored-line-number|line-number|json|tab|checkstyle
+  print-issued-lines: true
+  print-linter-name: true
+
+linters:
+  disable-all: true
+  enable:
+    - govet
+    # - errcheck
+    - staticcheck
+    - unused
+    - gosimple
+    - structcheck
+    - varcheck
+    - ineffassign
+    - deadcode
+    - typecheck
+    # default disabled
+    - gosec
+    - unconvert
+    - goconst
+    - goimports
+    - megacheck
+    - misspell
+    - nakedret
+    - prealloc
+    - gocritic
+
+linters-settings:
+  govet:
+    check-shadowing: true
+  errcheck:
+    check-type-assertions: false
+    check-blank: false
+  unused:
+    check-exported: false
+  goconst:
+    min-len: 3
+    min-occurrences: 3
+  misspell:
+    locale: US
+  nakedret:
+    max-func-lines: 30

--- a/notification/Makefile
+++ b/notification/Makefile
@@ -1,0 +1,17 @@
+PWD := $(shell pwd)
+
+.PHONY: all deps test
+
+all: test
+
+deps:
+	@docker run --rm -t -v "$(PWD)":/app -w /app \
+			golang:1.16.5-alpine3.13 go mod vendor
+
+test:
+	@docker run --rm -t -v "$(PWD)":/app -w /app \
+			golangci/golangci-lint:v1.40.1-alpine \
+			golangci-lint run --config .golangci.yml
+	@docker run --rm -t -v "$(PWD)":/app -w /app \
+			--entrypoint go golang:1.16.5-alpine3.13 \
+			test -vet off $(go list ./...)

--- a/notification/cmd/client/main.go
+++ b/notification/cmd/client/main.go
@@ -87,7 +87,8 @@ func makeConnection() (*grpc.ClientConn, error) {
 			log.Fatalf("Could not make cert pool: %v", err)
 		}
 		cred := credentials.NewTLS(&tls.Config{
-			RootCAs: systemRoots,
+			RootCAs:    systemRoots,
+			MinVersion: tls.VersionTLS12,
 		})
 		opts = append(opts, grpc.WithTransportCredentials(cred))
 	}


### PR DESCRIPTION
golangci/golanci-lint でチェックしたところ、gosec の警告が確認されまして。

Makefile 使いたくないとか、golangci/golanci-lint 好きじゃないとか、
その他のリンターの警告は流儀に沿わないとかあると思ったので
最低限以下のファイルの修正だけでもいいかもではあります。
`notification/cmd/client/main.go`